### PR TITLE
add pyserial for esp32 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ RUN apt-get update && apt-get install -y wget bzip2 curl && rm -rf /var/lib/apt/
 RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=/usr/local/bin sh
 
 FROM python:slim as arduino-cli
+
+# pyserial is needed for esp32 builds, probably shouldn't be needed but doesn't compile without it
+RUN pip install pyserial 
+
 COPY --from=0 /usr/local/bin/arduino-cli /usr/local/bin/arduino-cli
 COPY .cli-config.yml /
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
This was a little bit of a quick fix, trying to do a arduino-cli compile with the image was throwing this error for esp32 builds:

```
ImportError: No module named serial
```

The dependency only looked necessary for uploading and I was only compiling but I didn't really spend much time digging into this, this was a quick fix and doesn't seem like it has much impact.

I thought I would open a PR to see if you were interested in merging and I can abandon my fork.

If you aren't interested in this, no worries!

Thanks for making this, nice work!