### PR TITLE
update adafruit url

### DIFF
--- a/.cli-config.yml
+++ b/.cli-config.yml
@@ -1,3 +1,3 @@
 board_manager:
   additional_urls:
-    - https://www.adafruit.com/package_adafruit_index.json
+    - https://adafruit.github.io/arduino-board-index/package_adafruit_index.json


### PR DESCRIPTION
replaces all instances of https://www.adafruit.com/package_adafruit_index.json with https://adafruit.github.io/arduino-board-index/package_adafruit_index.json